### PR TITLE
Fix test errors - pre-existing output file and case-sensitive file extension

### DIFF
--- a/tests/test_loc.py
+++ b/tests/test_loc.py
@@ -16,6 +16,8 @@ from sd_file_parser import parseLocationFiles
 class LocationParsingTest(unittest.TestCase):
 
     def testBasicParserRun(self):
+        if os.path.exists("displacement.csv"):
+            os.remove("displacement.csv")
         parseLocationFiles( inputFileName = self.inputfn, kind='LOC', outputFileName=self.outputfn )
         self.assertTrue( os.path.exists( self.outputfn ) ) 
         self.assertFalse( os.path.exists( 'displacement.csv' ) )

--- a/tests/test_sst.py
+++ b/tests/test_sst.py
@@ -39,7 +39,7 @@ class SSTParsingTest(unittest.TestCase):
         prepare for running the parser
         """
         self.inputfn = 'example_data/2021-01-15/0235_SST.CSV'
-        self.outputfn = 'sst.CSV'
+        self.outputfn = 'sst.csv'
         
     def tearDown(self):
         """


### PR DESCRIPTION
When I ran the tests on my Linux machine I ran into the following errors:

1. `test_loc.py:21`: `displacement.csv` existed (from a previous test case) so the assertion failed.
2. `test_sst.py:25`: The assertion failed because the actual created file had a lowercase extension and `self.outputfn` had an uppercase (`.CSV`) extension.

This PR fixes these two errors.