### PR TITLE
Make argname normalization robust and exit 1 if invalid arg

### DIFF
--- a/sd_file_parser.py
+++ b/sd_file_parser.py
@@ -160,6 +160,7 @@ Major Updates:
 # Implementation
 #----------------
 #
+import inspect
 import numpy
 import os
 
@@ -1440,34 +1441,19 @@ def validCommandLineArgument( arg ):
         #
     key,val = out
     
-    if key.lower() in ['path']:
-        #
-        key = 'path'
-        #
-    elif  key.lower() in ['outputfiletype']:
-        #
-        key = 'outputFileType'
-        #
-    elif key.lower() in ['spectra']:
-        #
-        key = 'spectra'
-        #
-    elif key.lower() in ['lffilter']:
-        #
-        key = 'lfFilter'
-        #
-    elif key.lower() in ['bulkparameters']:
-        #
-        key = 'bulkParameters'
-        #
+    # normalize arg names to the capitalization required by main()
+    argnames = list(inspect.signature(main).parameters)
+    for argname in argnames:
+        if key.lower() == argname.lower():
+            key = argname
+            break
     else:
         #
         print('ERROR: unknown commandline argument ' + key)
-        sys.exit()
+        sys.exit(1)
         #
     return( key,val)
     #
-
 def getVersions( path ):
     """
      This function retrieves sha from sys filenames; if no sha is present

--- a/sd_file_parser.py
+++ b/sd_file_parser.py
@@ -1437,7 +1437,7 @@ def validCommandLineArgument( arg ):
     if not (len(out) == 2):
         #
         print('ERROR: Unknown commandline argument: ' + arg)
-        sys.exit()
+        sys.exit(1)
         #
     key,val = out
     


### PR DESCRIPTION
The existing code doesn't handle passing `outpath` nor some other args at the command line and the code for normalizing capitalization is brittle. This PR makes these both programmatic. Also, it exits with exitcode 1 (error) if the argname is invalid.