### PR TITLE
Restore the deprecated error_bad_lines argument to aid in parsing

### DIFF
--- a/sd_file_parser.py
+++ b/sd_file_parser.py
@@ -611,7 +611,7 @@ def parseLocationFiles( inputFileName=None, outputFileName='displacement.CSV',
         # Read the data using pandas, and convert to numpy
         #
         data = pd.read_csv( inputFileName ,
-                index_col=False , usecols=(1,2,3,4) )
+                index_col=False , usecols=(1,2,3,4), error_bad_lines=False )
         data = data.apply(pd.to_numeric,errors='coerce')
         data = data.values
 


### PR DESCRIPTION
Some FLT files cannot pass the parser without this flag, unless those files are hand-edited before parsing.

Note, this flag is deprecated.

```
Processing Spotter displacement output - FLT
/Users/tcj/src/spotter-sd-parser/sd_file_parser.py:613: FutureWarning: The error_bad_lines argument has been deprecated and will be removed in a future version. Use on_bad_lines in the future.
```