### PR TITLE
Ignore incomplete lines at ends of input files & retire legacy SST parsing

### DIFF
--- a/sd_file_parser.py
+++ b/sd_file_parser.py
@@ -544,11 +544,15 @@ def main( path = None , outpath=None, outputFileType='CSV',
                     #parse the mean location/displacement files; 
                     #this step transforms unix epoch to date string.
                     #
-                    parseLocationFiles(inputFileName = fileName, kind=suffix,
+                    try:
+                        parseLocationFiles(inputFileName = fileName, kind=suffix,
                             outputFileName = fileName,
                             outputFileType=outputFileType,
                             versionNumber=version['number'],
                             IIRWeightType=version['IIRWeightType'])
+                    except OSError as e:
+                        print(f"Error in parseLocationFiles() while parsing {fileName}: {e}")
+                        raise
                     #
                 elif suffix in ['SPC']:
                     #

--- a/sd_file_parser.py
+++ b/sd_file_parser.py
@@ -284,8 +284,6 @@ class Spectrum:
 
     def _load_parser_output( self ):
         #
-        import numpy
-        import os
         for key in self._parser_files:
             if self._file_available[key]:
                 data = numpy.loadtxt( os.path.join(self.path,self._parser_files[key]) , delimiter=',' )
@@ -307,16 +305,12 @@ class Spectrum:
 
 
     def _moment(self , values ):
-        import numpy
-
         df = numpy.mean(numpy.diff( self.f))
         E = self.Szz * values
         jstart =3
         return numpy.trapz(  E[:,jstart:],self.f[jstart:] ,1  )
 
     def _weighted_moment(self , values ):
-        import numpy
-
         return self._moment( values ) / self._moment(1.)
 
     @property
@@ -335,11 +329,9 @@ class Spectrum:
             return self._weighted_moment( self.b1 )
 
     def _peak_index(self):
-        import numpy
         return numpy.argmax( self.Szz,1 )
 
     def _direction(self,a1,b1):
-        import numpy
         directions = 270 - numpy.arctan2( b1 , a1 ) * self._toDeg
 
         for ii,direction in enumerate(directions):
@@ -355,7 +347,6 @@ class Spectrum:
         return self._direction(self.a1m,self.b1m)
 
     def _spread(self,a1,b1):
-        import numpy
         return numpy.sqrt(  2 - 2 * numpy.sqrt( a1**2 + b1**2 ) ) * self._toDeg
 
     def mean_spread(self):
@@ -395,11 +386,9 @@ class Spectrum:
         return 1. / self._weighted_moment( self.f )
 
     def significant_wave_height(self):
-        import numpy
         return 4.*numpy.sqrt(self._moment( 1.))
 
     def generate_text_file(self):
-        import os
         hm0   = self.significant_wave_height()
         tm01  = self.mean_period()
         tp    = self.peak_period()
@@ -431,25 +420,38 @@ def main( path = None , outpath=None, outputFileType='CSV',
     routine is called by __main__ and that calls in succession the separate 
     routines to concatenate, and parse files. 
     """
-    import os
-
 
     #Check the version of Files
     versions =  getVersions( path )
-    
+
     #The filetypes to concatenate
     if suffixes is None:
-        #
-        suffixes    = ['FLT','SPC','SYS','LOC','GPS','SST']
-        #
-    
-        
+        suffixes = [
+            'FLT',
+            'SPC',
+            'SYS',
+            'LOC',
+            'GPS',
+            'SST',
+        ]
+
     if parsing is None:
-        #
-        parsing=['FLT','SPC','LOC','SST']
-        #
-    #
-        
+        parsing = [
+            'FLT',
+            'SPC',
+            'LOC',
+            'SST',
+        ]
+
+    if any( [ version['number'] < 3 for version in versions ] ):
+        print("WARNING: This parser version no longer supports legacy SST files (firmware 1.12.x and below).")
+        print("         If you need to parse legacy SST files, please use the parser in the legacy/ subdirectory.")
+        print("Press enter to confirm:")
+        input()
+        log_errors("Warned about skipping legacy SST parsing.")
+        for collection in suffixes, parsing:
+            collection.remove('SST')
+
     outFiles    = {'FLT':'displacement','SPC':'spectra','SYS':'system',
                        'LOC':'location','GPS':'gps','SST':'sst'}
 
@@ -489,7 +491,7 @@ def main( path = None , outpath=None, outputFileType='CSV',
     if len(versions) == 1:
         # if there is only a single version- we allow all files to be parsed.
         # this is a clutch to account for the fact that sys files are not
-        # garantueed to be written. In general assuming everything is the
+        # guaranteed to be written. In general assuming everything is the
         # same version seems safe- allowing to parse multiple different
         # versions is perhaps something we want to stop supporting as it adds
         # a lot of fragile logic.
@@ -516,8 +518,8 @@ def main( path = None , outpath=None, outputFileType='CSV',
             os.makedirs(outpath)
             #
         #            
-        
-        for suffix  in suffixes:
+
+        for suffix in suffixes:
             #
             fileName = os.path.join( outpath , outFiles[suffix] + '.csv' )
             # 
@@ -539,7 +541,12 @@ def main( path = None , outpath=None, outputFileType='CSV',
             #
             if suffix in parsing:
                 #
-                if suffix in ['FLT','LOC','GPS','SST']:
+                if suffix in [
+                    'FLT',
+                    'LOC',
+                    'GPS',
+                    'SST',
+                ]:
                     #
                     #parse the mean location/displacement files; 
                     #this step transforms unix epoch to date string.
@@ -577,9 +584,9 @@ def main( path = None , outpath=None, outputFileType='CSV',
             spectrum.generate_text_file()
     #Versions
     #
+    print("Done.")
 
 #end def
-
 
 
 def log_errors( error ):
@@ -601,11 +608,8 @@ def parseLocationFiles( inputFileName=None, outputFileName='displacement.CSV',
     a Spotter into one datastructure and saves the result as a CSV file 
     (*outputFileName*).
     """
-
-    import os
     import pandas as pd
     import numpy as np
-    import time
     #
 
     fname,ext = os.path.splitext(outputFileName)
@@ -707,9 +711,6 @@ def parseLocationFiles( inputFileName=None, outputFileName='displacement.CSV',
         #
     #
 
-    
-
-
     if outputFileType.lower() in ['csv','gz']:
         #
         np.savetxt(outputFileName ,
@@ -798,11 +799,9 @@ def parseSpectralFiles(   inputFileName=None, outputPath = None,
     # a Spotter into one datastructure and saves the result as a CSV file
     # (*outputFileName*).
     #
-    import os
     import pandas as pd
     import numpy as np
-    import time
-    
+
     def checkKeyNames(key,errorLocation):
         # Nested function to make sure input is insensitive to capitals,
         # irrelevant permutations (Cxz vs Czx), etc
@@ -914,7 +913,7 @@ def parseSpectralFiles(   inputFileName=None, outputPath = None,
     #
     # Read csv file using Pandas - this is the only section in the code
     # still reliant on Pandas, and only there due to supposed performance
-    # benifits.
+    # benefits.
     tmp = pd.read_csv( inputFileName ,
                 index_col=False , skiprows=[0],  header=None,
                     usecols=tuple(range(2,5+stride*nf)) )
@@ -1077,7 +1076,6 @@ def getFileNames( path , suffix , message,versionFileList=None ):
     # This function returns all the filenames in a given *path*
     # that conform to ????_YYY.CSV where YYY is given by *suffix*.
     #
-    import os
     import fnmatch
     
     if path is None:
@@ -1166,96 +1164,9 @@ def cat( path = None, outputFileName = 'displacement.CSV', Suffix='FLT',
             compatibility_version=defaultVersion):
     """
     This functions concatenates raw csv files with a header. Only for the first 
-    file it retains the header. Note that for SPEC files and SST files special
-    processing is done. Specifically, for SST files we map the millis timebase
-    onto the epochtime base using a relation estimated from the FLT files.
+    file it retains the header. Note that for SPEC files special
+    processing is done.
     """
-    import os
-    import pandas as pd
-    import numpy as np
-
-    def get_epoch_to_milis_relation( sst_file ):
-        #
-        # This function gets the relation between milis and epoch from the
-        # FLT file. This assumes FLT exist, otherwise we get an error
-        #
-
-        head,tail = os.path.split( sst_file )
-        tail = tail.replace('SST','FLT')
-
-        flt_file = os.path.join(head,tail)
-        if os.path.exists( flt_file ) == False:
-            raise missingFLTFile('No FLT file found for SST file')
-
-        data = pd.read_csv( flt_file ,index_col=False , usecols=(0,1))
-        data = data.apply(pd.to_numeric,errors='coerce')
-        data = data.values
-        msk = np.isnan( data[:,0] )
-        for ii in range( 0, data.ndim ):
-            msk = np.isfinite(data[:,ii])
-            data = data[msk,:]
-        data = data[msk,:]
-        millis = data[:,0]
-        epochs = data[:,1]
-
-        ii  = numpy.argmax( millis)
-
-        if ii < 10:
-            raise Exception('Roll-over in millis')
-
-        def millis_to_epoch(milis_in):
-            return int(epochs[0] + ( milis_in - millis[0] ) \
-                   * ( epochs[ii] - epochs[0] ) / ( millis[ii] - millis[0] ))
-
-        return millis_to_epoch
-
-    def process_sst_lines( lines, infile ):
-        #
-        # Get the function that maps milis to epochs
-        #
-        # max int used for roll-over; Spotter millis clock resets after reaching
-        # the max ints.
-        max = 4294967295
-
-        #Get the millis to epoch mapping from the FLT file
-        millis_to_epoch = get_epoch_to_milis_relation(infile)
-
-        # Do a line by line processing, replacing millis with epochtime from
-        # the mapping
-        outlines = []                #Store the output lines
-        previousvalue = 0
-        for line in lines:
-            if 'millis' in line:
-                # header
-                outlines.append(line)
-            else:
-                #
-                data = line.strip().split(',')
-                # last line can be empty, check if there are two entries (as expected)
-                if len(data) == 2:
-
-                    # Look at the delta, millis should be monotonically increasing
-                    # unless we hit roll-over
-                    delta = int(data[0]) - previousvalue
-
-                    # If the delta is negative, wrap the value
-                    if delta < -4294000000:
-                        delta = delta + max
-
-                    # New value from (potentially) corrected delta
-                    value = previousvalue + delta
-
-                    #Convert to epochtime from mapping
-                    epoch = millis_to_epoch( value )
-                    outlines.append(str( epoch ) + ' , ' + data[1])
-                    previousvalue = value
-                else:
-                    # malformed line
-                    pass
-
-        return '\n'.join(outlines) + '\n'
-
-    import os
     import gzip
     #
 
@@ -1264,8 +1175,6 @@ def cat( path = None, outputFileName = 'displacement.CSV', Suffix='FLT',
         # Here we detect if we are in debug or in production mode, we do this
         # based on the first few lines; in debug these will contain either
         # FFT or SPEC, whereas in production only SPECA is encountered
-        import os
-        
         mode = 'production'
         with open(os.path.join( path,filename) ) as infile:
             #
@@ -1283,7 +1192,7 @@ def cat( path = None, outputFileName = 'displacement.CSV', Suffix='FLT',
     
     def find_nth(haystack, needle, n):
         #
-        # Function to find nth and nth-1 occurences of a needle in the haystack
+        # Function to find nth and nth-1 occurrences of a needle in the haystack
         #
         start = haystack.find(needle)
         prev  = start
@@ -1303,20 +1212,13 @@ def cat( path = None, outputFileName = 'displacement.CSV', Suffix='FLT',
                         message='_'+Suffix,versionFileList=versionFileList )
     #
     if len(fileNames) == 0:
-        return(False)
+        return False
     
     fname,ext = os.path.splitext(outputFileName)
     outputFileName = fname + '.' + extensions(outputFileType)
     #
-    if outputFileType.lower()=='gz':
-        #
-        compress=True
-        #
-    else:
-        #
-        compress=False
-        #    
-    #
+    compress = outputFileType.lower()=='gz'
+
     if compress:
         #
         outfile = gzip.open(outputFileName,'wb')
@@ -1422,18 +1324,6 @@ def cat( path = None, outputFileName = 'displacement.CSV', Suffix='FLT',
 
                     if index > 0 and len(lines):
                         unused_header = lines.pop(0)
-                        
-                    #
-                    # If SST file, map millis onto epochs
-                    if Suffix == 'SST':
-                        if compatibility_version < 3:
-                            try:
-                                lines = process_sst_lines(lines, fqfn)
-                            except missingFLTFile:
-                                message = "- ERROR:, no FLT file found for SST file " + fqfn + " - skipping"
-                                log_errors(message)
-                                print(message)
-                                continue
 
                     if compress:
                         #
@@ -1449,7 +1339,7 @@ def cat( path = None, outputFileName = 'displacement.CSV', Suffix='FLT',
         #
     #
     outfile.close()
-    return( True )
+    return True
     #
 #end def
 
@@ -1503,8 +1393,6 @@ def getVersions( path ):
      processed in the same way (this may go across firmware versions).
     """
     
-    import os
-
     # Get sys files
     path,fileNames = getFileNames( path , 'SYS' , 'system' )
     #


### PR DESCRIPTION
Historically the parser script has run into issues when the following occurs:
* CSV input files contain incomplete lines at the ends of files
* these files are concatenated together in `cat()`
* the post-processing encounters malformed lines joined together, which sometimes take the form of wildly large timestamps 

The proposed solution is to ignore lines that do not end in `\n` -- typically this will be the last line in the file, if that line is incomplete.  Risk of losing valid data is minimal.  This, then, protects against incomplete lines being joined to other lines in the concatenation routine.

The most straightforward implementation was to switch from using `readlines()` (which does not include the trailing `\n` in input lines` with `for line in f` or `readline()` (in the singular).

from https://docs.python.org/3/tutorial/inputoutput.html —

> f.readline() reads a single line from the file; a newline character (\n) is left at the end of the string, and is only omitted on the last line of the file if the file doesn’t end in a newline. 

Changing this code would have necessitated also changing the mapping of legacy SST rows to timestamps from FLT files.  That support has now been omitted, in favor of asking users to instead try the legacy parser archived in the `legacy/` subdirectory of this repo.
