### PR TITLE
trapz is deprecated and throws a warning. switching to trapezoid

### DIFF
--- a/sd_file_parser.py
+++ b/sd_file_parser.py
@@ -310,7 +310,7 @@ class Spectrum:
         df = numpy.mean(numpy.diff( self.f))
         E = self.Szz * values
         jstart =3
-        return numpy.trapz(  E[:,jstart:],self.f[jstart:] ,1  )
+        return numpy.trapezoid(  E[:,jstart:],self.f[jstart:] ,1  )
 
     def _weighted_moment(self , values ):
         return self._moment( values ) / self._moment(1.)


### PR DESCRIPTION
tested with unit tests.